### PR TITLE
Implement proof verification and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A robust, n-ary Merkle Tree implementation in C with comprehensive testing and d
 - **Queue-based Construction**: Efficient bottom-up tree building algorithm
 - **Memory Safe**: Comprehensive error handling and memory management
 - **Opaque API**: Clean public interface with implementation details hidden
+- **Proof Verification**: Validate proofs against a known root hash
 - **Comprehensive Tests**: Full unit test suite with memory leak detection
 - **Documentation**: Complete Doxygen-generated API documentation
 

--- a/include/Merkle.h
+++ b/include/Merkle.h
@@ -133,5 +133,22 @@ merkle_error_t generate_proof_from_index(const merkle_tree_t *tree, size_t leaf_
  */
 merkle_error_t generate_proof_by_finder(const merkle_tree_t *tree, value_finder finder, size_t *path_length, merkle_proof_t** proof);
 
+/**
+ * @brief Verify a Merkle proof against a known root hash.
+ *
+ * Recomputes the hash chain from the supplied leaf data using the proof path
+ * and compares the resulting root hash to @p expected_root.
+ *
+ * @param proof         Pointer to the proof to verify.
+ * @param expected_root Expected root hash of the tree.
+ * @param leaf_data     Data contained in the proved leaf.
+ * @param leaf_size     Size of @p leaf_data in bytes.
+ * @return MERKLE_SUCCESS if the proof matches the root, MERKLE_PROOF_INVALID on
+ *         mismatch or an error code on invalid arguments.
+ */
+merkle_error_t verify_proof(const merkle_proof_t *proof,
+                            const unsigned char expected_root[HASH_SIZE],
+                            const void *leaf_data, size_t leaf_size);
+
 
 #endif // MERKLE_H

--- a/include/Utils.h
+++ b/include/Utils.h
@@ -38,18 +38,12 @@
 #define ALLOC_AND_INIT_SIMPLE(name,count)\
     do{\
         name = MMalloc((count) * sizeof(*(name)));\
-        if(name){\
-            memset(name,0,(count) * sizeof(*(name)));\
-        }\
     }while(0)
 
 #define ALLOC_AND_INIT(T,name,count)\
     T* name = NULL;\
     do{\
         name = MMalloc((count) * sizeof(*(name)));\
-        if(name){\
-            memset(name,0,(count) * sizeof(*(name)));\
-        }\
     }while(0)
 
     
@@ -76,6 +70,7 @@ void merkle_init_signal_protection(void);
  * @brief Cleanup signal protection for current thread  
  */
 void merkle_cleanup_signal_protection(void);
+
 
 /**
  * @brief Safe memory access pattern that catches segfaults

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -6,11 +6,13 @@
 # Compiler and flags
 CC = clang
 CFLAGS = -Werror -std=c11 -g -O0 -Wno-deprecated-declarations -Wno-incompatible-pointer-types-discards-qualifiers -Wno-unused-parameter
-OPENSSL_ROOT = /opt/homebrew/Cellar/openssl@3/3.5.0
 
-# Include and library paths
-INCLUDES = -I../include -I$(OPENSSL_ROOT)/include
-LDFLAGS = -L$(OPENSSL_ROOT)/lib -lssl -lcrypto
+# Use pkg-config if available to find OpenSSL
+OPENSSL_CFLAGS ?= $(shell pkg-config --cflags openssl 2>/dev/null)
+OPENSSL_LIBS  ?= $(shell pkg-config --libs openssl 2>/dev/null)
+
+INCLUDES = -I../include $(OPENSSL_CFLAGS)
+LDFLAGS = $(OPENSSL_LIBS)
 
 # Source files
 SRC_DIR = ../src


### PR DESCRIPTION
## Summary
- add proof verification API and tests
- calculate proof path length dynamically
- fix sibling hash allocation
- add optional signal handler disabling
- use pkg-config for OpenSSL in test Makefile
- document new features and signal handling in README
- simplify allocation macros
- prevent integer overflow in tree build
- remove public signal handler toggle from Utils.h

## Testing
- `cd tests && ./run_tests.sh > ../test.log`


------
https://chatgpt.com/codex/tasks/task_e_685e0129ada483289629e51b84ff247d