### PR TITLE
Add filesystem example

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,21 @@ merkle_tree_t *ternary_tree = merkle_tree_create(data, sizes, count, 3);
 merkle_tree_t *wide_tree = merkle_tree_create(data, sizes, count, 8);
 ```
 
+### Real-World Example: Filesystem Verification
+
+An end-to-end example is available in [`examples/filesystem`](examples/filesystem).
+It builds a tree from files on disk, generates a proof for `file2.txt` and
+verifies it.
+
+To build and run:
+
+```bash
+cd examples/filesystem
+clang filesystem_example.c ../../src/merkle_tree.c ../../src/merkle_queue.c \
+      ../../src/merkle_utils.c -I../../include -lssl -lcrypto -o fs_example
+./fs_example
+```
+
 ### Error Handling
 
 ```c

--- a/examples/filesystem/README.md
+++ b/examples/filesystem/README.md
@@ -1,0 +1,25 @@
+# Filesystem Proof Example
+
+This example demonstrates how to build a Merkle tree from files on disk and
+verify the inclusion of a specific file. Three sample text files are provided in
+the `data` directory. The program builds a binary Merkle tree from all files,
+prints the resulting root hash, generates a proof for `file2.txt` and verifies
+it.
+
+## Building
+
+Run the following command from this directory:
+
+```bash
+clang filesystem_example.c ../../src/merkle_tree.c ../../src/merkle_queue.c \
+      ../../src/merkle_utils.c -I../../include -lssl -lcrypto -o fs_example
+```
+
+## Running
+
+```
+./fs_example
+```
+
+The program outputs the tree root hash and a verification message for
+`file2.txt`.

--- a/examples/filesystem/data/file1.txt
+++ b/examples/filesystem/data/file1.txt
@@ -1,0 +1,1 @@
+Hello World

--- a/examples/filesystem/data/file2.txt
+++ b/examples/filesystem/data/file2.txt
@@ -1,0 +1,1 @@
+Merkle Trees are cool

--- a/examples/filesystem/data/file3.txt
+++ b/examples/filesystem/data/file3.txt
@@ -1,0 +1,1 @@
+Another file for the Merkle tree

--- a/examples/filesystem/filesystem_example.c
+++ b/examples/filesystem/filesystem_example.c
@@ -1,0 +1,95 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <dirent.h>
+#include <sys/stat.h>
+#include "../include/Merkle.h"
+
+/* Helper function to read an entire file into memory */
+static int read_file(const char *path, unsigned char **buffer, size_t *size) {
+    FILE *f = fopen(path, "rb");
+    if (!f) return 0;
+    struct stat st;
+    if (stat(path, &st) != 0) { fclose(f); return 0; }
+    *size = st.st_size;
+    *buffer = malloc(*size);
+    if (!*buffer) { fclose(f); return 0; }
+    if (fread(*buffer, 1, *size, f) != *size) { fclose(f); free(*buffer); return 0; }
+    fclose(f);
+    return 1;
+}
+
+int main(void) {
+    const char *dir = "data";
+    DIR *d = opendir(dir);
+    if (!d) {
+        perror("opendir");
+        return 1;
+    }
+
+    size_t cap = 4;
+    size_t count = 0;
+    unsigned char **data = malloc(cap * sizeof(*data));
+    size_t *sizes = malloc(cap * sizeof(*sizes));
+    struct dirent *ent;
+    while ((ent = readdir(d))) {
+        if (ent->d_type != DT_REG) continue;
+        if (count == cap) {
+            cap *= 2;
+            data = realloc(data, cap * sizeof(*data));
+            sizes = realloc(sizes, cap * sizeof(*sizes));
+        }
+        char path[256];
+        snprintf(path, sizeof(path), "%s/%s", dir, ent->d_name);
+        if (!read_file(path, &data[count], &sizes[count])) {
+            fprintf(stderr, "Failed to read %s\n", path);
+            closedir(d);
+            return 1;
+        }
+        count++;
+    }
+    closedir(d);
+
+    if (count == 0) {
+        fprintf(stderr, "No files found\n");
+        return 1;
+    }
+
+    merkle_tree_t *tree = create_merkle_tree((const void **)data, sizes, count, 2);
+    if (!tree) {
+        fprintf(stderr, "Failed to build Merkle tree\n");
+        return 1;
+    }
+
+    unsigned char root[HASH_SIZE];
+    if (get_tree_hash(tree, root) != MERKLE_SUCCESS) {
+        fprintf(stderr, "Failed to get root hash\n");
+        dealloc_merkle_tree(tree);
+        return 1;
+    }
+
+    printf("Root hash: ");
+    for (size_t i = 0; i < HASH_SIZE; ++i) printf("%02x", root[i]);
+    printf("\n");
+
+    /* Generate and verify proof for the second file (index 1) */
+    if (count > 1) {
+        merkle_proof_t *proof = NULL;
+        if (generate_proof_from_index(tree, 1, &proof) == MERKLE_SUCCESS) {
+            if (verify_proof(proof, root, data[1], sizes[1]) == MERKLE_SUCCESS) {
+                printf("Proof for file 2 verified successfully!\n");
+            } else {
+                printf("Verification failed!\n");
+            }
+        } else {
+            printf("Failed to generate proof for file 2\n");
+        }
+    }
+
+    dealloc_merkle_tree(tree);
+    for (size_t i = 0; i < count; ++i) free(data[i]);
+    free(data);
+    free(sizes);
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- create `examples/filesystem` with sample text files
- add a small C demo that builds a Merkle tree from files, creates a proof and verifies it
- document the new example in README

## Testing
- `./tests/run_tests.sh`
- `clang filesystem_example.c ../../src/merkle_tree.c ../../src/merkle_queue.c ../../src/merkle_utils.c -I../../include -lssl -lcrypto -o fs_example && ./fs_example`

------
https://chatgpt.com/codex/tasks/task_e_685e3f4d8b0883289af81e18c7a840c8