### PR TITLE
Add shared library build and Python example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+CC=clang
+CFLAGS=-fPIC -std=c11 -O2 -Wall \
+        -Wno-deprecated-declarations \
+        -Wno-incompatible-pointer-types-discards-qualifiers \
+        -Wno-unused-parameter -pthread \
+        -D_GNU_SOURCE -D_XOPEN_SOURCE=700
+
+OPENSSL_CFLAGS := $(shell pkg-config --cflags openssl 2>/dev/null)
+OPENSSL_LIBS   := $(shell pkg-config --libs openssl 2>/dev/null)
+ifeq ($(strip $(OPENSSL_LIBS)),)
+OPENSSL_ROOT ?= /opt/homebrew/Cellar/openssl@3/3.5.0
+OPENSSL_CFLAGS := -I$(OPENSSL_ROOT)/include
+OPENSSL_LIBS   := -L$(OPENSSL_ROOT)/lib -lssl -lcrypto
+endif
+
+INCLUDES=-Iinclude $(OPENSSL_CFLAGS)
+LDFLAGS=$(OPENSSL_LIBS) -shared -pthread
+
+SRC=$(wildcard src/*.c)
+OBJ=$(SRC:.c=.o)
+TARGET=libmerkle.so
+
+all: $(TARGET)
+
+$(TARGET): $(OBJ)
+	$(CC) -o $@ $^ $(LDFLAGS)
+
+%.o: %.c
+	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@
+
+clean:
+	rm -f $(OBJ) $(TARGET)
+
+.PHONY: all clean

--- a/README.md
+++ b/README.md
@@ -144,6 +144,20 @@ if (!tree) {
     return -1;
 }
 ```
+## 🐍 Python Integration
+
+Build the shared library and use it from Python with `ctypes`. First build `libmerkle.so`:
+
+```bash
+make
+```
+
+Then run the example script:
+
+```bash
+python examples/python_ctypes_example.py
+```
+
 
 ## 🧪 Testing
 

--- a/examples/python_ctypes_example.py
+++ b/examples/python_ctypes_example.py
@@ -1,0 +1,45 @@
+import ctypes
+import os
+
+# Load the shared library
+lib_path = os.path.join(os.path.dirname(__file__), '..', 'libmerkle.so')
+merkle = ctypes.CDLL(lib_path)
+
+# Define argument and return types
+merkle.create_merkle_tree.restype = ctypes.c_void_p
+merkle.create_merkle_tree.argtypes = [ctypes.POINTER(ctypes.c_void_p),
+                                      ctypes.POINTER(ctypes.c_size_t),
+                                      ctypes.c_size_t,
+                                      ctypes.c_size_t]
+
+merkle.dealloc_merkle_tree.restype = None
+merkle.dealloc_merkle_tree.argtypes = [ctypes.c_void_p]
+
+merkle.get_tree_hash.restype = ctypes.c_int
+merkle.get_tree_hash.argtypes = [ctypes.c_void_p,
+                                 ctypes.c_char * 32]
+
+def build_tree(data):
+    count = len(data)
+    arr_type = ctypes.c_void_p * count
+    size_type = ctypes.c_size_t * count
+
+    data_ptrs = arr_type()
+    sizes = size_type()
+
+    for i, block in enumerate(data):
+        buf = ctypes.create_string_buffer(block)
+        data_ptrs[i] = ctypes.cast(buf, ctypes.c_void_p)
+        sizes[i] = len(block)
+
+    tree = merkle.create_merkle_tree(data_ptrs, sizes, count, 2)
+    if not tree:
+        raise RuntimeError('Failed to create Merkle tree')
+    return tree
+
+if __name__ == '__main__':
+    tree = build_tree([b'foo', b'bar', b'baz'])
+    hash_buf = (ctypes.c_char * 32)()
+    if merkle.get_tree_hash(tree, hash_buf) == 0:
+        print('Root hash:', hash_buf.raw.hex())
+    merkle.dealloc_merkle_tree(tree)


### PR DESCRIPTION
## Summary
- compile Merkle Tree as a shared library via new Makefile
- add example of using the shared library from Python with `ctypes`
- document Python integration in README

## Testing
- `make clean`
- `make`
- `cd tests && ./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68622999e81c8328924643b404bd918e